### PR TITLE
[fix] 🏀 상품 상세 내역 동일 버그 해결

### DIFF
--- a/app/(head)/cart/page.tsx
+++ b/app/(head)/cart/page.tsx
@@ -209,7 +209,7 @@ export default function CartPage() {
 
     postPurchaseMutate({
       purchaseList: selectedItems,
-      totalPrice: calculateTotalPrice(),
+      totalPrice: calculateTotalPrice() + calculateDeliveryFee(),
       totalDiscountPrice: calculateTotalSavings(),
     });
 

--- a/components/molecules/PaymentDetailCard.tsx
+++ b/components/molecules/PaymentDetailCard.tsx
@@ -46,6 +46,7 @@ function PaymentDetailCard({
       prevPrice: price,
       search: false,
     });
+    setNew_quantity(1);
   };
 
   const onCountChange = (pid: number, count: number) => {

--- a/components/molecules/sion/ProductCard.tsx
+++ b/components/molecules/sion/ProductCard.tsx
@@ -44,6 +44,7 @@ export const ProductCard = ({ searchResult }: { searchResult: Search }) => {
       prevPrice: searchResult.storeList[seletedProduct].price,
       search: true,
     });
+    setQuantity(1);
   };
 
   return (


### PR DESCRIPTION
## 📖 관련 페이지

- 장바구니, 검색페이지, 거래내역 상세 페이지

## 📝 기능 설명

- 장바구니 담고나서 수량 초기화 안되는 버그 수정, 구매 시 배달비도 포함해서 totalPrice에 추가

  <br/>

## 🐥 추가적인 언급 사항
